### PR TITLE
Added installation instructions for Arch-based Linux distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ With **nPhoneKIT**, there’s no "magic click" – just real commands and real t
   python main.py
   ```
 
+---
+
 ### Linux (Debian-based distro) 🐧
 
 - Go to the latest release, download Source Code as ZIP.


### PR DESCRIPTION
- Created a new heading for Arch-based distros (line 89).
- Added instructions for installing missing dependencies in Arch environments, using ``pacman`` (lines 91-108).
- Renamed generic "Linux" title to "Linux (Debian-based distro)" (line 76), since there are now two Linux sections.